### PR TITLE
Makefile: drop rebuild of the atemsys module before cleaning it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ modules_install:
 	$(MAKE) -C $(KERNELDIR) M=$(shell pwd) modules_install
 
 clean:
-	$(MAKE) -C $(KERNELDIR) M=$(shell pwd) modules clean
+	$(MAKE) -C $(KERNELDIR) M=$(shell pwd) clean


### PR DESCRIPTION
It's not necessary to build the module before cleaning