### PR TITLE
docs: fix typos and numbering in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ atemsys can be built natively on the target device:
 ```bash
 git clone https://github.com/acontis/atemsys.git
 ```
-#### 2) Install kernel headers if neccessary, e.g.
+#### 2) Install kernel headers if necessary, e.g.
 ```bash
 sudo apt-get install linux-headers-$(uname -r)
 ```
@@ -32,7 +32,7 @@ sudo apt-get install linux-headers-$(uname -r)
 cd atemsys
 make modules
 ```
-#### 3) Load the atemsys module
+#### 4) Load the atemsys module
 ```bash
 sudo insmod atemsys.ko
 ```


### PR DESCRIPTION
## Summary

This PR fixes two small but noticeable issues in the installation instructions of `Readme.md`:

### Changes

1. **Line 25 — Typo fix**: `neccessary` → `necessary`  
   The word *necessary* was misspelled in the step _"Install kernel headers if neccessary"_.

2. **Line 35 — Numbering fix**: `#### 3) Load the atemsys module` → `#### 4) Load the atemsys module`  
   Step 3 appeared twice in the numbered list (the previous line was also numbered `3)`).  
   Renamed the second occurrence to `4)` to maintain a correct sequential order.

### Diff

```diff
- #### 2) Install kernel headers if neccessary, e.g.
+ #### 2) Install kernel headers if necessary, e.g.

- #### 3) Load the atemsys module
+ #### 4) Load the atemsys module
```

### Motivation

Correct documentation helps users follow installation steps without confusion. The typo and the duplicate step number are both minor individually but together make the instructions look careless.

---

🤖 Generated by [Hermes PR Bot](https://github.com/lingxiaoyiyu-hub) · Repository: `acontis/atemsys` (56 ⭐)
